### PR TITLE
Fixed a bug in bcm2835_stream.cpp's millis. Function is millis but ha…

### DIFF
--- a/src/source/bcm2835_stream.cpp
+++ b/src/source/bcm2835_stream.cpp
@@ -9,7 +9,7 @@ uint32_t millis()
 {
 	struct timeval now;
 	gettimeofday(&now, NULL);
-	return (uint32_t)now.tv_usec;
+	return (uint32_t) ( now.tv_usec / 1000 );
 }
 
 Stream::Stream(const char* port)


### PR DESCRIPTION
…s been returning microseconds instead of milliseconds.